### PR TITLE
Prevents nodes from linking to an invalid target + new test case

### DIFF
--- a/src/backbone.c
+++ b/src/backbone.c
@@ -180,7 +180,7 @@ Node *Backbone_create(void *meta_n)
  *****************************************************************************/
 void Backbone_link(Node *orig, Node *dest, void *meta_e)
 {
-	if (!dest || !linked(orig, dest)) {
+	if (orig && dest && !linked(orig, dest)) {
 		orig->edges = ealloc(orig, 1);
 		orig->edges[orig->count_e]->from = orig;
 		orig->edges[orig->count_e]->to = dest;

--- a/tests/test_backbone.c
+++ b/tests/test_backbone.c
@@ -151,6 +151,20 @@ START_TEST(test_cannot_link_node_more_than_once_same_target)
 END_TEST
 
 
+START_TEST(test_cannot_link_to_null_target)
+{
+    Node *n1 = Backbone_create(NULL);
+    Node *n2 = NULL;
+
+    Backbone_link(n1, n2, NULL);
+
+    ck_assert_int_eq(n1->count_e, 0);
+
+    Backbone_destroy(&n1);
+}
+END_TEST
+
+
 START_TEST(test_can_unlink_two_linked_nodes)
 {
 	Node *n1 = Backbone_create(NULL);
@@ -251,6 +265,7 @@ Suite *TSuite_backbone(void)
 	tcase_add_test(tc, test_can_link_multiple_nodes);
 	tcase_add_test(tc, test_can_link_node_to_itself);
 	tcase_add_test(tc, test_cannot_link_node_more_than_once_same_target);
+    tcase_add_test(tc, test_cannot_link_to_null_target);
 	suite_add_tcase(s, tc);
 
 	tc = tcase_create("NODE_UNLINKING");

--- a/tests/test_backbone.h
+++ b/tests/test_backbone.h
@@ -14,6 +14,7 @@
  *        test_can_link_multiple_nodes
  *        test_can_link_node_to_itself
  *        test_cannot_link_node_more_than_once_same_target
+ *        test_cannot_link_node_to_null_target
  *
  *        [NODE_UNLINKING]
  *        test_can_unlink_two_linked_nodes


### PR DESCRIPTION
Fixing condition in function `Backbone_link` to avoid node pointing to `NULL`. Also includes a new test case. This test case fails when run with the "old" `Backbone_link`.
